### PR TITLE
시드파인더 적용

### DIFF
--- a/core/src/main/assets/messages/items/items.properties
+++ b/core/src/main/assets/messages/items/items.properties
@@ -3859,6 +3859,10 @@ items.heap.skeleton=Skeletal remains
 items.heap.skeleton_desc=This is all that's left of some unfortunate adventurer. Maybe it's worth checking for any valuables.
 items.heap.remains=Hero's remains
 items.heap.remains_desc=This is all that's left from one of your predecessors. Maybe it's worth checking for any valuables.
+items.heap.mimic=Mimic
+items.heap.golden_mimic=Golden Mimic
+items.heap.crystal_mimic=Crystal Mimic
+items.heap.statue=Animated Statue
 
 items.honeypot.name=honeypot
 items.honeypot.ac_shatter=SHATTER

--- a/core/src/main/assets/messages/items/items_ko.properties
+++ b/core/src/main/assets/messages/items/items_ko.properties
@@ -3879,6 +3879,10 @@ items.heap.skeleton=해골 잔해
 items.heap.skeleton_desc=불행한 모험가가 남긴 모든 것이 이 잔해에 있다. 귀중품이 있는지 뒤져볼 만한 가치가 있어 보인다.
 items.heap.remains=영웅의 유해
 items.heap.remains_desc=당신의 전임자의 잔해. 귀중품이 있는지 뒤져 볼 만한 가치가 있어 보인다.
+items.heap.mimic=미믹
+items.heap.golden_mimic=황금 미믹
+items.heap.crystal_mimic=수정 미믹
+items.heap.statue=움직이는 석상
 
 items.honeypot.name=꿀단지
 items.honeypot.ac_shatter=깨트린다

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/SeedFinder.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/SeedFinder.java
@@ -1,0 +1,495 @@
+package com.shatteredpixel.shatteredpixeldungeon;
+
+import com.shatteredpixel.shatteredpixeldungeon.actors.hero.HeroClass;
+import com.shatteredpixel.shatteredpixeldungeon.actors.mobs.ArmoredStatue;
+import com.shatteredpixel.shatteredpixeldungeon.actors.mobs.CrystalMimic;
+import com.shatteredpixel.shatteredpixeldungeon.actors.mobs.GoldenMimic;
+import com.shatteredpixel.shatteredpixeldungeon.actors.mobs.Mimic;
+import com.shatteredpixel.shatteredpixeldungeon.actors.mobs.Mob;
+import com.shatteredpixel.shatteredpixeldungeon.actors.mobs.Statue;
+import com.shatteredpixel.shatteredpixeldungeon.actors.mobs.npcs.Ghost;
+import com.shatteredpixel.shatteredpixeldungeon.actors.mobs.npcs.Imp;
+import com.shatteredpixel.shatteredpixeldungeon.actors.mobs.npcs.Wandmaker;
+import com.shatteredpixel.shatteredpixeldungeon.items.Dewdrop;
+import com.shatteredpixel.shatteredpixeldungeon.items.EnergyCrystal;
+import com.shatteredpixel.shatteredpixeldungeon.items.Gold;
+import com.shatteredpixel.shatteredpixeldungeon.items.Heap;
+import com.shatteredpixel.shatteredpixeldungeon.items.Heap.Type;
+import com.shatteredpixel.shatteredpixeldungeon.items.Item;
+import com.shatteredpixel.shatteredpixeldungeon.items.armor.Armor;
+import com.shatteredpixel.shatteredpixeldungeon.items.artifacts.Artifact;
+import com.shatteredpixel.shatteredpixeldungeon.items.keys.CrystalKey;
+import com.shatteredpixel.shatteredpixeldungeon.items.keys.GoldenKey;
+import com.shatteredpixel.shatteredpixeldungeon.items.keys.IronKey;
+import com.shatteredpixel.shatteredpixeldungeon.items.potions.Potion;
+import com.shatteredpixel.shatteredpixeldungeon.items.quest.CeremonialCandle;
+import com.shatteredpixel.shatteredpixeldungeon.items.quest.CorpseDust;
+import com.shatteredpixel.shatteredpixeldungeon.items.quest.Embers;
+import com.shatteredpixel.shatteredpixeldungeon.items.quest.Pickaxe;
+import com.shatteredpixel.shatteredpixeldungeon.items.rings.Ring;
+import com.shatteredpixel.shatteredpixeldungeon.items.scrolls.Scroll;
+import com.shatteredpixel.shatteredpixeldungeon.items.wands.Wand;
+import com.shatteredpixel.shatteredpixeldungeon.items.weapon.Weapon;
+import com.shatteredpixel.shatteredpixeldungeon.items.weapon.melee.MeleeWeapon;
+import com.shatteredpixel.shatteredpixeldungeon.levels.Level;
+import com.shatteredpixel.shatteredpixeldungeon.utils.DungeonSeed;
+import com.watabou.utils.Random;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.List;
+
+public class SeedFinder {
+	enum Condition {ANY, ALL}
+	enum FINDING {STOP,CONTINUE}
+
+	public static FINDING findingStatus = FINDING.STOP;
+
+	public static class Options {
+		public static int floors;
+		public static Condition condition;
+		public static long seed;
+	}
+
+	static class HeapItem {
+		public Item item;
+		public Heap heap;
+
+		public HeapItem(Item item, Heap heap) {
+			this.item = item;
+			this.heap = heap;
+		}
+	}
+
+	List<Class<? extends Item>> blacklist;
+	ArrayList<String> itemList;
+
+	private void addTextItems(String caption, ArrayList<HeapItem> items, StringBuilder builder) {
+		if (!items.isEmpty()) {
+			builder.append(caption).append(":\n");
+
+			for (HeapItem item : items) {
+				Item i = item.item;
+				Heap h = item.heap;
+
+				if (((i instanceof Armor && ((Armor) i).hasGoodGlyph()) ||
+					(i instanceof Weapon && ((Weapon) i).hasGoodEnchant()) ||
+					(i instanceof Ring) || (i instanceof Wand)) && i.cursed)
+					builder.append("- 저주받은 ").append(i.title().toLowerCase());
+
+				else
+					builder.append("- ").append(i.title().toLowerCase());
+
+				if (h.type != Type.HEAP)
+					builder.append(" (").append(h.title().toLowerCase()).append(")");
+
+				builder.append("\n");
+			}
+
+			builder.append("\n");
+		}
+	}
+
+	private void addTextQuest(String caption, ArrayList<Item> items, StringBuilder builder) {
+		if (!items.isEmpty()) {
+			builder.append(caption).append(":\n");
+
+			for (Item i : items) {
+				if (i.cursed)
+					builder.append("- 저주받은 ").append(i.title().toLowerCase()).append("\n");
+
+				else
+					builder.append("- ").append(i.title().toLowerCase()).append("\n");
+			}
+
+			builder.append("\n");
+		}
+	}
+
+
+
+	public void findSeed(boolean stop){
+		if(!stop){
+			findingStatus = FINDING.STOP;
+		}
+	}
+
+	public String findSeed(String[] wanted, int floor) {
+		itemList = new ArrayList<>(Arrays.asList(wanted));
+
+		String seedDigits = Integer.toString(Random.Int(500000));
+		findingStatus = FINDING.CONTINUE;
+		Options.condition = Condition.ALL;
+
+		String result="NONE";
+
+		for (int i = Random.Int(9999999); i < DungeonSeed.TOTAL_SEEDS && findingStatus == FINDING.CONTINUE ; i++) {
+			if (testSeedALL(seedDigits + i, floor)) {
+				result = logSeedItems(seedDigits + Integer.toString(i), floor);
+				break;
+			}
+		}
+		return result;
+	}
+
+	private ArrayList<Heap> getMobDrops(Level l) {
+		ArrayList<Heap> heaps = new ArrayList<>();
+
+		for (Mob m : l.mobs) {
+			if (m instanceof Statue) {
+				Heap h = new Heap();
+				h.items = new LinkedList<>();
+				h.items.add(((Statue) m).weapon.identify());
+				h.type = Type.STATUE;
+				heaps.add(h);
+			}
+
+			else if (m instanceof ArmoredStatue) {
+				Heap h = new Heap();
+				h.items = new LinkedList<>();
+				h.items.add(((ArmoredStatue) m).armor.identify());
+				h.items.add(((ArmoredStatue) m).weapon.identify());
+				h.type = Type.STATUE;
+				heaps.add(h);
+			}
+
+			else if (m instanceof Mimic) {
+				Heap h = new Heap();
+				h.items = new LinkedList<>();
+
+				for (Item item : ((Mimic) m).items)
+					h.items.add(item.identify());
+
+				if (m instanceof GoldenMimic) h.type = Type.GOLDEN_MIMIC;
+				else if (m instanceof CrystalMimic) h.type = Type.CRYSTAL_MIMIC;
+				else h.type = Type.MIMIC;
+				heaps.add(h);
+			}
+		}
+
+		return heaps;
+	}
+
+	private boolean testSeed(String seed, int floors) {
+		SPDSettings.customSeed(seed);
+		GamesInProgress.selectedClass = HeroClass.WARRIOR;
+		Dungeon.init();
+
+		boolean[] itemsFound = new boolean[itemList.size()];
+
+		for (int i = 0; i < floors; i++) {
+			Level l = Dungeon.newLevel();
+
+			ArrayList<Heap> heaps = new ArrayList<>(l.heaps.valueList());
+			heaps.addAll(getMobDrops(l));
+			
+			if(Ghost.Quest.armor != null){
+				for (int j = 0; j < itemList.size(); j++) {
+					if (Ghost.Quest.armor.identify().title().toLowerCase().replaceAll(" ","").contains(itemList.get(j).replaceAll(" ",""))) {
+						if (itemsFound[j] == false) {
+							itemsFound[j] = true;
+							break;
+						}
+					}
+				}
+			}
+			if(Wandmaker.Quest.wand1 != null){
+				for (int j = 0; j < itemList.size(); j++) {
+					if (Wandmaker.Quest.wand1.identify().title().toLowerCase().replaceAll(" ","").contains(itemList.get(j).replaceAll(" ","")) || Wandmaker.Quest.wand2.identify().title().toLowerCase().replaceAll(" ","").contains(itemList.get(j).replaceAll(" ",""))) {
+						if (itemsFound[j] == false) {
+							itemsFound[j] = true;
+							break;
+						}
+					}	
+					if(Wandmaker.Quest.type == 1 && "시체먼지".contains(itemList.get(j).replaceAll(" ",""))){
+						if (itemsFound[j] == false) {
+							itemsFound[j] = true;
+							break;
+						}
+					}else if(Wandmaker.Quest.type == 2 && "정령의잉걸불".contains(itemList.get(j).replaceAll(" ",""))){
+						if (itemsFound[j] == false) {
+							itemsFound[j] = true;
+							break;
+						}
+					}else if(Wandmaker.Quest.type == 3 && "썩은열매의씨앗".contains(itemList.get(j).replaceAll(" ",""))){
+						if (itemsFound[j] == false) {
+							itemsFound[j] = true;
+							break;
+						}
+					}
+				}
+			}
+			if(Imp.Quest.reward != null){
+				for (int j = 0; j < itemList.size(); j++) {
+					if (Imp.Quest.reward.identify().title().toLowerCase().replaceAll(" ","").contains(itemList.get(j).replaceAll(" ",""))) {
+						if (itemsFound[j] == false) {
+							itemsFound[j] = true;
+							break;
+						}
+					}
+				}
+			}
+
+			for (Heap h : heaps) {
+				for (Item item : h.items) {
+					item.identify();
+
+					for (int j = 0; j < itemList.size(); j++) {
+						if (item.title().toLowerCase().replaceAll(" ","").contains(itemList.get(j).replaceAll(" ",""))) {
+							if (itemsFound[j] == false) {
+								itemsFound[j] = true;
+								break;
+							}
+						}
+					}
+				}
+			}
+
+			Dungeon.depth++;
+		}
+
+		if (Options.condition == Condition.ANY) {
+			for (int i = 0; i < itemList.size(); i++) {
+				if (itemsFound[i] == true)
+					return true;
+			}
+
+			return false;
+		}
+
+		else {
+			for (int i = 0; i < itemList.size(); i++) {
+				if (itemsFound[i] == false)
+					return false;
+			}
+
+			return true;
+		}
+	}
+
+	private boolean testSeedALL(String seed, int floors) {
+		SPDSettings.customSeed(seed);
+		GamesInProgress.selectedClass = HeroClass.WARRIOR;
+		Dungeon.init();
+
+		boolean[] itemsFound = new boolean[itemList.size()];
+		Arrays.fill(itemsFound, false);
+
+		for (int i = 0; i < floors; i++) {
+			Level l = Dungeon.newLevel();
+
+			ArrayList<Heap> heaps = new ArrayList<>(l.heaps.valueList());
+			heaps.addAll(getMobDrops(l));
+
+			if(Ghost.Quest.armor != null){
+				for (int j = 0; j < itemList.size(); j++) {
+					String wantingItem = itemList.get(j);
+					boolean precise = wantingItem.startsWith("\"")&&wantingItem.endsWith("\"");
+					if(precise){
+						wantingItem = wantingItem.replaceAll(" ", "");
+					}else{
+						wantingItem = wantingItem.replaceAll("\"","");
+					}
+					if (!precise&&Ghost.Quest.armor.identify().title().toLowerCase().replaceAll(" ","").contains(wantingItem) || precise&& Ghost.Quest.armor.identify().title().toLowerCase().equals(wantingItem)) {
+						if (itemsFound[j] == false) {
+							itemsFound[j] = true;
+							break;
+						}
+					}
+				}
+			}
+			if(Wandmaker.Quest.wand1 != null){
+				for (int j = 0; j < itemList.size(); j++) {
+					String wantingItem = itemList.get(j);
+					String wand1 = Wandmaker.Quest.wand1.identify().title().toLowerCase();
+					String wand2 = Wandmaker.Quest.wand2.identify().title().toLowerCase();
+					boolean precise = wantingItem.startsWith("\"")&&wantingItem.endsWith("\"");
+					if(precise){
+						wantingItem = wantingItem.replaceAll("\"","");
+						if (wand1.equals(wantingItem) || wand2.equals(wantingItem)) {
+							if (itemsFound[j] == false) {
+								itemsFound[j] = true;
+								break;
+							}
+						}
+					}else{
+						wantingItem = wantingItem.replaceAll(" ", "");
+						wand1 = wand1.replaceAll(" ","");
+						wand2 = wand2.replaceAll(" ","");
+						if (wand1.contains(wantingItem) || wand2.contains(wantingItem)) {
+							if (itemsFound[j] == false) {
+								itemsFound[j] = true;
+								break;
+							}
+						}
+					}
+					if(Wandmaker.Quest.type == 1 && "시체먼지".contains(wantingItem.replaceAll(" ",""))){
+						if (itemsFound[j] == false) {
+							itemsFound[j] = true;
+							break;
+						}
+					}else if(Wandmaker.Quest.type == 2 && "정령의잉걸불".contains(wantingItem.replaceAll(" ",""))){
+						if (itemsFound[j] == false) {
+							itemsFound[j] = true;
+							break;
+						}
+					}else if(Wandmaker.Quest.type == 3 && "썩은열매의씨앗".contains(wantingItem.replaceAll(" ",""))){
+						if (itemsFound[j] == false) {
+							itemsFound[j] = true;
+							break;
+						}
+					}
+				}
+			}
+			if(Imp.Quest.reward != null){
+				for (int j = 0; j < itemList.size(); j++) {
+					String wantingItem = itemList.get(j);
+					boolean precise = wantingItem.startsWith("\"")&&wantingItem.endsWith("\"");
+					String ring = Imp.Quest.reward.identify().title().toLowerCase();
+					if (!precise&&ring.replaceAll(" ","").contains(wantingItem.replaceAll(" ",""))
+					||
+					precise&& ring.equals(wantingItem)) {
+						if (itemsFound[j] == false) {
+							itemsFound[j] = true;
+							break;
+						}
+					}
+				}
+			}
+
+			for (Heap h : heaps) {
+				for (Item item : h.items) {
+					item.identify();
+					String itemName = item.title().toLowerCase();
+
+					for (int j = 0; j < itemList.size(); j++) {
+						String wantingItem = itemList.get(j);
+						boolean precise = wantingItem.startsWith("\"")&&wantingItem.endsWith("\"");
+						if (!precise&&itemName.replaceAll(" ","").contains(wantingItem.replaceAll(" ",""))
+						|| precise&& itemName.equals(wantingItem.replaceAll("\"", ""))) {
+							if (itemsFound[j] == false) {
+								itemsFound[j] = true;
+								break;
+							}
+						}
+					}
+				}
+			}
+			if(areAllTrue(itemsFound)){
+				return true;
+			}
+			Dungeon.depth++;
+		}
+		return false;
+	}
+
+	private static boolean areAllTrue(boolean[] array)
+	{
+		for(boolean b : array) if(!b) return false;
+		return true;
+	}
+
+	public String logSeedItems(String seed, int floors) {
+		
+		SPDSettings.customSeed(seed);
+		GamesInProgress.selectedClass = HeroClass.WARRIOR;
+		Dungeon.init();
+		StringBuilder result = new StringBuilder("시드 " + DungeonSeed.convertToCode(Dungeon.seed) + " (" + Dungeon.seed + ") 의 아이템들:\n\n");
+
+		blacklist = Arrays.asList(Gold.class, Dewdrop.class, IronKey.class, GoldenKey.class, CrystalKey.class, EnergyCrystal.class,
+								  CorpseDust.class, Embers.class, CeremonialCandle.class, Pickaxe.class);
+
+
+		for (int i = 0; i < floors; i++) {
+			result.append("\n_----- ").append(Long.toString(Dungeon.depth)).append("층 -----_\n\n");
+
+			Level l = Dungeon.newLevel();
+			ArrayList<Heap> heaps = new ArrayList<>(l.heaps.valueList());
+			StringBuilder builder = new StringBuilder();
+			ArrayList<HeapItem> scrolls = new ArrayList<>();
+			ArrayList<HeapItem> potions = new ArrayList<>();
+			ArrayList<HeapItem> equipment = new ArrayList<>();
+			ArrayList<HeapItem> rings = new ArrayList<>();
+			ArrayList<HeapItem> artifacts = new ArrayList<>();
+			ArrayList<HeapItem> wands = new ArrayList<>();
+			ArrayList<HeapItem> others = new ArrayList<>();
+			ArrayList<HeapItem> forSales = new ArrayList<>();
+
+			// list quest rewards
+			if (Ghost.Quest.armor != null) {
+				ArrayList<Item> rewards = new ArrayList<>();
+				rewards.add(Ghost.Quest.armor.identify());
+				rewards.add(Ghost.Quest.weapon.identify());
+				Ghost.Quest.complete();
+
+				addTextQuest("[ 슬픈 유령 퀘스트 보상 ]", rewards, builder);
+			}
+
+			if (Wandmaker.Quest.wand1 != null) {
+				ArrayList<Item> rewards = new ArrayList<>();
+				rewards.add(Wandmaker.Quest.wand1.identify());
+				rewards.add(Wandmaker.Quest.wand2.identify());
+				Wandmaker.Quest.complete();
+
+				builder.append("[ 지팡이 깎는 노인의 요구 아이템 ]:\n ");
+
+
+				switch (Wandmaker.Quest.type) {
+					case 1: default:
+						builder.append("시체 먼지\n\n");
+						break;
+					case 2:
+						builder.append("정령의 잉걸불\n\n");
+						break;
+					case 3:
+						builder.append("썩은열매의 씨앗\n\n");
+				}
+
+				addTextQuest("[ 지팡이 깎는 노인의 퀘스트 보상 ]", rewards, builder);
+			}
+
+			if (Imp.Quest.reward != null) {
+				ArrayList<Item> rewards = new ArrayList<>();
+				rewards.add(Imp.Quest.reward.identify());
+				Imp.Quest.complete();
+
+				addTextQuest("[ 임프 퀘스트 보상 ]", rewards, builder);
+			}
+
+			heaps.addAll(getMobDrops(l));
+
+			// list items
+			for (Heap h : heaps) {
+				for (Item item : h.items) {
+					item.identify();
+
+					if (h.type == Type.FOR_SALE) forSales.add(new HeapItem(item, h));
+					else if (blacklist.contains(item.getClass())) continue;
+					else if (item instanceof Scroll) scrolls.add(new HeapItem(item, h));
+					else if (item instanceof Potion) potions.add(new HeapItem(item, h));
+					else if (item instanceof MeleeWeapon || item instanceof Armor) equipment.add(new HeapItem(item, h));
+					else if (item instanceof Ring) rings.add(new HeapItem(item, h));
+					else if (item instanceof Artifact) artifacts.add(new HeapItem(item, h));
+					else if (item instanceof Wand) wands.add(new HeapItem(item, h));
+					else others.add(new HeapItem(item, h));
+				}
+			}
+
+			addTextItems("[ 주문서 ]", scrolls, builder);
+			addTextItems("[ 물약 ]", potions, builder);
+			addTextItems("[ 장비 ]", equipment, builder);
+			addTextItems("[ 반지 ]", rings, builder);
+			addTextItems("[ 유물 ]", artifacts, builder);
+			addTextItems("[ 마법 막대 ]", wands, builder);
+			addTextItems("[ 상점 ]", forSales, builder);
+			addTextItems("[ 그 외 ]", others, builder);
+
+			result.append("\n").append(builder);
+
+			Dungeon.depth++;
+		}
+		return result.toString();
+    }
+
+}

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/actors/mobs/ArmoredStatue.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/actors/mobs/ArmoredStatue.java
@@ -41,7 +41,7 @@ public class ArmoredStatue extends Statue {
 		spriteClass = StatueSprite.class;
 	}
 
-	protected Armor armor;
+	public Armor armor;
 
 	public ArmoredStatue(){
 		super();

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/actors/mobs/Statue.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/actors/mobs/Statue.java
@@ -47,7 +47,7 @@ public class Statue extends Mob {
 		properties.add(Property.INORGANIC);
 	}
 	
-	protected Weapon weapon;
+	public Weapon weapon;
 
 	public boolean levelGenStatue = true;
 	

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/actors/mobs/npcs/Wandmaker.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/actors/mobs/npcs/Wandmaker.java
@@ -221,7 +221,7 @@ public class Wandmaker extends NPC {
 	
 	public static class Quest {
 
-		private static int type;
+		public static int type;
 		// 1 = corpse dust quest
 		// 2 = elemental embers quest
 		// 3 = rotberry quest

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/Heap.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/Heap.java
@@ -67,7 +67,11 @@ public class Heap implements Bundlable {
 		CRYSTAL_CHEST,
 		TOMB,
 		SKELETON,
-		REMAINS
+		REMAINS,
+		MIMIC,
+		GOLDEN_MIMIC,
+		CRYSTAL_MIMIC,
+		STATUE
 	}
 	public Type type = Type.HEAP;
 	
@@ -378,6 +382,14 @@ public class Heap implements Bundlable {
 				return Messages.get(this, "skeleton");
 			case REMAINS:
 				return Messages.get(this, "remains");
+			case MIMIC:
+				return Messages.get(this, "mimic");
+			case GOLDEN_MIMIC:
+				return Messages.get(this, "golden_mimic");
+			case CRYSTAL_MIMIC:
+				return Messages.get(this, "crystal_mimic");
+			case STATUE:
+				return Messages.get(this, "statue");
 			default:
 				return peek().title();
 		}


### PR DESCRIPTION
- 시드파인더 추가를 위한 몇 가지 수정 작업..
- SeedFinder.java 추가

```java
import com.shatteredpixel.shatteredpixeldungeon.SeedFinder;
...

new SeedFinder().logSeedItem("asdf",30);
//asdf시드의 1~30층까지 아이템 모두 return함

new SeedFinder().findSeed(["글레이브 +3","부유함의 반지 +1","\"검\""],5);
//1~5층까지 글레이브3강,부반1강,"검" 이 있는 시드를 찾고 그 시드의 아이템들을 return함
//문제점: 찾을 때까지 무한로딩 -> 강제종료
```